### PR TITLE
Fix mobile navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,10 +5,12 @@ import ProjectsView from "./views/projectsView/ProjectsView";
 import ResumeView from "./views/resumeView/ResumeView";
 import ContactView from "./views/contactView/ContactView";
 import { Navbar } from "./components/navbar/Navbar";
+import { ScrollToTop } from "./hooks/scrollTopTop";
 
 const App = () => {
   return (
     <BrowserRouter basename="/portfolio">
+      <ScrollToTop />
       <Navbar />
       <main>
         <Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import ProjectsView from "./views/projectsView/ProjectsView";
 import ResumeView from "./views/resumeView/ResumeView";
 import ContactView from "./views/contactView/ContactView";
 import { Navbar } from "./components/navbar/Navbar";
-import { ScrollToTop } from "./hooks/scrollTopTop";
+import { useScrollToTopOnPathChange as ScrollToTop } from "./hooks/useScrollToTopOnPathChange";
 
 const App = () => {
   return (

--- a/src/components/navbar/Navbar.css
+++ b/src/components/navbar/Navbar.css
@@ -72,17 +72,14 @@
 .menu {
   display: none;
   position: fixed;
-  right: 0;
-  top: calc(var(--spacing-xl) + 2px);
-  width: 250px;
+  top: var(--spacing-xl);
+  width: calc(100dvw - 2 * var(--spacing-xs));
+  max-height: calc(100% - var(--spacing-xl) - 2 * var(--spacing-s));
+  padding: var(--spacing-s) var(--spacing-xs);
   background-color: var(--navbar-menu);
-  flex-direction: column;
   gap: var(--spacing-xs);
-  padding: var(--spacing-s);
-  border-bottom-left-radius: 25px;
   overflow-y: auto;
   overflow-x: hidden;
-  max-height: calc(90dvh - var(--spacing-xl));
 }
 
 .menu a {
@@ -112,6 +109,7 @@
 
   .menu {
     display: flex;
+    flex-direction: column;
   }
 }
 

--- a/src/components/navbar/Navbar.css
+++ b/src/components/navbar/Navbar.css
@@ -5,6 +5,7 @@
   right: 0;
   height: var(--spacing-xl);
   background-color: var(--navbar-background);
+  border-bottom: 2px solid var(--navbar-shadow);
   display: flex;
   align-items: center;
   gap: var(--spacing-xl);
@@ -64,17 +65,24 @@
   width: 1.5rem;
 }
 
+.menu-open {
+  overflow: hidden;
+}
+
 .menu {
   display: none;
   position: fixed;
   right: 0;
-  top: var(--spacing-xl);
+  top: calc(var(--spacing-xl) + 2px);
   width: 250px;
   background-color: var(--navbar-menu);
   flex-direction: column;
   gap: var(--spacing-xs);
   padding: var(--spacing-s);
   border-bottom-left-radius: 25px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  max-height: calc(90dvh - var(--spacing-xl));
 }
 
 .menu a {

--- a/src/components/navbar/Navbar.css
+++ b/src/components/navbar/Navbar.css
@@ -49,9 +49,10 @@
 }
 
 .menuButton {
-  display: none;
+  display: block;
   position: absolute;
   right: 0;
+  top: 0;
   background-color: transparent !important;
   color: var(--text-color) !important;
   border: 0;
@@ -69,10 +70,16 @@
   overflow: hidden;
 }
 
+.menu-open main {
+  filter: brightness(50%);
+  background-color: var(--background-color);
+}
+
 .menu {
-  display: none;
+  display: block;
   position: fixed;
-  top: var(--spacing-xl);
+  top: calc(var(--spacing-xl) + 2px);
+  left: 0;
   width: calc(100dvw - 2 * var(--spacing-xs));
   max-height: calc(100% - var(--spacing-xl) - 2 * var(--spacing-s));
   padding: var(--spacing-s) var(--spacing-xs);
@@ -102,14 +109,12 @@
   .darkModeButtonContainer {
     display: none;
   }
+}
 
-  .menuButton {
-    display: block;
-  }
-
+@media (min-width: 601px) {
+  .menuButton,
   .menu {
-    display: flex;
-    flex-direction: column;
+    display: none;
   }
 }
 

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -4,6 +4,7 @@ import { FaBars as MenuIcon } from "react-icons/fa6";
 import { useOnClickOutsideRefs } from "../../hooks/useOnClickOutsideRefs";
 import { ToggleButton } from "../toggleButton/ToggleButton";
 import { useColorScheme } from "../../hooks/useColorScheme";
+import { useFocusTrap } from "../../hooks/useFocusTrap";
 import "./Navbar.css";
 
 const navigationLinks = [
@@ -14,29 +15,63 @@ const navigationLinks = [
 
 export const Navbar = () => {
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const mobileMenuContainerRef = useRef<HTMLDivElement>(null);
   const mobileMenuRef = useRef<HTMLDivElement>(null);
   const mobileMenuButtonRef = useRef<HTMLButtonElement>(null);
   const menuRefs = [mobileMenuRef, mobileMenuButtonRef];
   const { isDark, handleDarkModeToggle } = useColorScheme();
 
+  // Trap focus inside mobile menu when it's open
+  useFocusTrap(isMobileMenuOpen, mobileMenuContainerRef);
+
   const toggleMobileMenu = () => {
-    setMobileMenuOpen(!isMobileMenuOpen);
-    if (!isMobileMenuOpen) {
+    const newMobileMenuState = !isMobileMenuOpen;
+    // Clicking outside the menu closes the menu but doesn't do anything else
+    if (newMobileMenuState) {
+      // Open the menu
+      document.body.style.pointerEvents = "none";
+      if (mobileMenuContainerRef.current) {
+        mobileMenuContainerRef.current.style.pointerEvents = "auto";
+      }
       document.body.classList.add("menu-open");
     } else {
+      // Close the menu
+      document.body.style.pointerEvents = "auto";
       document.body.classList.remove("menu-open");
     }
+    setMobileMenuOpen(newMobileMenuState);
   };
 
   useOnClickOutsideRefs(menuRefs, toggleMobileMenu);
 
   const { pathname } = useLocation();
 
+  // Close mobile menu if location is changed
   useEffect(() => {
     if (pathname && isMobileMenuOpen) {
       toggleMobileMenu();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname]);
+
+  // Close mobile menu if 'Escape' key is pressed and move focus to the menu button
+  useEffect(() => {
+    if (!isMobileMenuOpen) {
+      return;
+    }
+
+    const closeOnEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        toggleMobileMenu();
+        mobileMenuButtonRef?.current?.focus();
+      }
+    };
+
+    window.addEventListener("keydown", closeOnEsc);
+
+    return () => window.removeEventListener("keydown", closeOnEsc);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isMobileMenuOpen]);
 
   return (
     <nav className="navbar">
@@ -57,39 +92,41 @@ export const Navbar = () => {
           label="Dark mode"
         />
       </div>
-      <button
-        ref={mobileMenuButtonRef}
-        className="menuButton"
-        onClick={toggleMobileMenu}
-        aria-expanded={isMobileMenuOpen}
-        aria-label={`${isMobileMenuOpen ? "Close" : "Open"} menu`}
-      >
-        <MenuIcon />
-      </button>
-      {isMobileMenuOpen && (
-        <div
-          className="menu"
-          ref={mobileMenuRef}
-          role="dialog"
-          aria-label="Menu"
+      <div ref={mobileMenuContainerRef}>
+        <button
+          ref={mobileMenuButtonRef}
+          className="menuButton"
+          onClick={toggleMobileMenu}
+          aria-expanded={isMobileMenuOpen}
+          aria-label={`${isMobileMenuOpen ? "Close" : "Open"} menu`}
         >
-          {navigationLinks.map((link) => (
-            <NavLink className="navlink" to={link.to} key={link.to}>
-              {link.text}
-            </NavLink>
-          ))}
-          <div className="settingsContainer">
-            <p>
-              <strong>Settings</strong>
-            </p>
-            <ToggleButton
-              onClick={handleDarkModeToggle}
-              value={isDark}
-              label="Dark mode"
-            />
+          <MenuIcon />
+        </button>
+        {isMobileMenuOpen && (
+          <div
+            className="menu"
+            ref={mobileMenuRef}
+            role="dialog"
+            aria-label="Menu"
+          >
+            {navigationLinks.map((link) => (
+              <NavLink className="navlink" to={link.to} key={link.to}>
+                {link.text}
+              </NavLink>
+            ))}
+            <div className="settingsContainer">
+              <p>
+                <strong>Settings</strong>
+              </p>
+              <ToggleButton
+                onClick={handleDarkModeToggle}
+                value={isDark}
+                label="Dark mode"
+              />
+            </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </nav>
   );
 };

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -6,6 +6,13 @@ import { ToggleButton } from "../toggleButton/ToggleButton";
 import { useColorScheme } from "../../hooks/useColorScheme";
 import "./Navbar.css";
 
+const navigationLinks = [
+  { to: "/", text: "Home" },
+  { to: "/projects", text: "Projects" },
+  { to: "/cv", text: "CV" },
+  { to: "/contact", text: "Contact" },
+];
+
 export const Navbar = () => {
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
   const mobileMenuRef = useRef<HTMLDivElement>(null);
@@ -31,11 +38,11 @@ export const Navbar = () => {
         Home
       </NavLink>
       <div className="navlinks">
-        <NavLink className="navlink" to="/projects">
-          Projects
-        </NavLink>
-        <NavLink to="/cv">CV</NavLink>
-        <NavLink to="/contact">Contact</NavLink>
+        {navigationLinks.map((link) => (
+          <NavLink className="navlink" to={link.to} key={link.to}>
+            {link.text}
+          </NavLink>
+        ))}
       </div>
       <div className="darkModeButtonContainer">
         <ToggleButton
@@ -56,11 +63,11 @@ export const Navbar = () => {
       </button>
       {isMobileMenuOpen && (
         <div ref={mobileMenuRef} className="menu">
-          <NavLink className="navlink" to="/projects">
-            Projects
-          </NavLink>
-          <NavLink to="/cv">CV</NavLink>
-          <NavLink to="/contact">Contact</NavLink>
+          {navigationLinks.map((link) => (
+            <NavLink className="navlink" to={link.to} key={link.to}>
+              {link.text}
+            </NavLink>
+          ))}
           <div className="settingsContainer">
             <p>
               <strong>Settings</strong>

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -7,7 +7,6 @@ import { useColorScheme } from "../../hooks/useColorScheme";
 import "./Navbar.css";
 
 const navigationLinks = [
-  { to: "/", text: "Home" },
   { to: "/projects", text: "Projects" },
   { to: "/cv", text: "CV" },
   { to: "/contact", text: "Contact" },
@@ -20,7 +19,14 @@ export const Navbar = () => {
   const menuRefs = [mobileMenuRef, mobileMenuButtonRef];
   const { isDark, handleDarkModeToggle } = useColorScheme();
 
-  const toggleMobileMenu = () => setMobileMenuOpen(!isMobileMenuOpen);
+  const toggleMobileMenu = () => {
+    setMobileMenuOpen(!isMobileMenuOpen);
+    if (!isMobileMenuOpen) {
+      document.body.classList.add("menu-open");
+    } else {
+      document.body.classList.remove("menu-open");
+    }
+  };
 
   useOnClickOutsideRefs(menuRefs, toggleMobileMenu);
 
@@ -48,8 +54,7 @@ export const Navbar = () => {
         <ToggleButton
           onClick={handleDarkModeToggle}
           value={isDark}
-          offLabel="Light mode"
-          onLabel="Dark mode"
+          label="Dark mode"
         />
       </div>
       <button
@@ -57,12 +62,17 @@ export const Navbar = () => {
         className="menuButton"
         onClick={toggleMobileMenu}
         aria-expanded={isMobileMenuOpen}
-        aria-label="Menu"
+        aria-label={`${isMobileMenuOpen ? "Close" : "Open"} menu`}
       >
         <MenuIcon />
       </button>
       {isMobileMenuOpen && (
-        <div ref={mobileMenuRef} className="menu">
+        <div
+          className="menu"
+          ref={mobileMenuRef}
+          role="dialog"
+          aria-label="Menu"
+        >
           {navigationLinks.map((link) => (
             <NavLink className="navlink" to={link.to} key={link.to}>
               {link.text}
@@ -75,8 +85,7 @@ export const Navbar = () => {
             <ToggleButton
               onClick={handleDarkModeToggle}
               value={isDark}
-              offLabel="Light mode"
-              onLabel="Dark mode"
+              label="Dark mode"
             />
           </div>
         </div>

--- a/src/components/tag/Tag.tsx
+++ b/src/components/tag/Tag.tsx
@@ -12,7 +12,7 @@ const getTagProperties = (
   /* Use existing color if found from css, otherwise use default grey */
   const tagColor =
     computedStyle.getPropertyValue(`--color-${trimmedLabel}`) ||
-    computedStyle.getPropertyValue("--grey") ||
+    computedStyle.getPropertyValue("--grey-dark") ||
     "darkgrey";
 
   /* Determine whether black or white text should be used based on the

--- a/src/components/toggleButton/ToggleButton.tsx
+++ b/src/components/toggleButton/ToggleButton.tsx
@@ -4,13 +4,11 @@ import "./ToggleButton.css";
 export const ToggleButton = ({
   onClick,
   value,
-  offLabel,
-  onLabel,
+  label,
 }: {
   onClick: () => void;
   value: boolean;
-  offLabel: string;
-  onLabel: string;
+  label: string;
 }) => {
   return (
     <div className="toggleContainer">
@@ -18,10 +16,10 @@ export const ToggleButton = ({
         <button
           className={`toggleButton ${value ? "right" : "left"}`}
           onClick={onClick}
-          aria-label={value ? `Switch to ${offLabel}` : `Switch to ${onLabel}`}
+          aria-label={`Dark mode ${value ? "on" : "off"}`}
         ></button>
       </div>
-      <span aria-hidden="true">{onLabel}</span>
+      <span aria-hidden="true">{label}</span>
     </div>
   );
 };

--- a/src/hooks/scrollTopTop.tsx
+++ b/src/hooks/scrollTopTop.tsx
@@ -1,0 +1,13 @@
+import React, { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+/* Hook that scrolls to the top of the page when location is changed */
+export const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};

--- a/src/hooks/useFocusTrap.tsx
+++ b/src/hooks/useFocusTrap.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect } from "react";
+
+/* Trap focus inside an element, such as a menu window */
+export const useFocusTrap = (
+  active: boolean,
+  containerRef: React.RefObject<HTMLElement>
+) => {
+  useEffect(() => {
+    if (active && containerRef.current) {
+      const container = containerRef.current;
+      container.focus();
+
+      const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "Tab") {
+          const focusableElements = container.querySelectorAll(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+          );
+          const firstElement = focusableElements[0] as HTMLElement;
+          const lastElement = focusableElements[
+            focusableElements.length - 1
+          ] as HTMLElement;
+
+          if (e.shiftKey && document.activeElement === firstElement) {
+            e.preventDefault();
+            lastElement.focus();
+          } else if (!e.shiftKey && document.activeElement === lastElement) {
+            e.preventDefault();
+            firstElement.focus();
+          }
+        }
+      };
+
+      document.addEventListener("keydown", handleKeyDown);
+
+      return () => {
+        document.removeEventListener("keydown", handleKeyDown);
+      };
+    }
+  }, [active, containerRef]);
+};

--- a/src/hooks/useOnClickOutsideRefs.tsx
+++ b/src/hooks/useOnClickOutsideRefs.tsx
@@ -1,7 +1,8 @@
 import { RefObject, useEffect } from "react";
 
-/* Hook that detects whether user clicked outside the mobile menu
- * when it's open, in which case it should close */
+/* Hook that detects whether user clicked outside a component, in which
+case the callback function is triggered. Takes as parameters a list of refs
+and the callback function. */
 export const useOnClickOutsideRefs = (
   refs: Array<RefObject<HTMLElement>>,
   callback: () => void
@@ -12,17 +13,18 @@ export const useOnClickOutsideRefs = (
       return;
     }
 
-    const onDocumentMouseUp = (e: MouseEvent) => {
+    const onClick = (e: MouseEvent) => {
       const targetElement = e.target as HTMLElement;
       const refHasTarget = refs.find((r) => r.current?.contains(targetElement));
       if (!refHasTarget) {
+        e.preventDefault();
         callback();
       }
     };
 
-    document.addEventListener("mouseup", onDocumentMouseUp);
+    document.addEventListener("click", onClick);
     return () => {
-      document.removeEventListener("mouseup", onDocumentMouseUp);
+      document.removeEventListener("click", onClick);
     };
-  }, [refs]);
+  }, [refs, callback]);
 };

--- a/src/hooks/useOnClickOutsideRefs.tsx
+++ b/src/hooks/useOnClickOutsideRefs.tsx
@@ -1,5 +1,7 @@
 import { RefObject, useEffect } from "react";
 
+/* Hook that detects whether user clicked outside the mobile menu
+ * when it's open, in which case it should close */
 export const useOnClickOutsideRefs = (
   refs: Array<RefObject<HTMLElement>>,
   callback: () => void

--- a/src/hooks/useScrollToTopOnPathChange.tsx
+++ b/src/hooks/useScrollToTopOnPathChange.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
-/* Hook that scrolls to the top of the page when location is changed */
-export const ScrollToTop = () => {
+/* Scroll to the top of the page when location is changed */
+export const useScrollToTopOnPathChange = () => {
   const { pathname } = useLocation();
 
   useEffect(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -79,7 +79,8 @@
   --spacing-l: 2rem;
   --spacing-xl: 3rem;
   /* 100% device view height - navbar height, padding and margin */
-  --viewheight: calc(100dvh - var(--spacing-xl) - 3 * var(--spacing-l));
+  --viewheight: calc(100dvh - 2 * var(--spacing-xl) - var(--spacing-l));
+  --viewheight-mobile: calc(100dvh - 2 * var(--spacing-xl));
   /* 100% device view width - padding */
   --viewwidth: calc(100dvw - 2 * var(--spacing-l));
   --viewwidth-mobile: calc(100dvw - 2 * var(--spacing-ml));
@@ -105,6 +106,7 @@ body {
   -moz-osx-font-smoothing: grayscale;
   background-color: var(--background-color);
   color: var(--text-color);
+  height: calc(100dvh - var(--spacing-xl));
 }
 
 h1 {
@@ -118,7 +120,8 @@ a {
 main {
   min-height: var(--viewheight);
   padding: var(--spacing-l);
-  margin: var(--spacing-xl) 0 var(--spacing-ml);
+  padding-bottom: var(--spacing-xl);
+  margin-top: var(--spacing-xl);
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
@@ -130,9 +133,10 @@ main > div {
   width: calc(var(--max-content-width) - 2 * var(--spacing-l));
 }
 
-@media (max-width: 500px) {
+@media (max-width: 600px) {
   main {
-    padding-top: var(--spacing-s);
+    padding-top: 0;
+    min-height: var(--viewheight-mobile);
   }
 
   main > div {
@@ -140,7 +144,7 @@ main > div {
   }
 }
 
-@media (min-width: 501px) and (max-width: 800px) {
+@media (min-width: 601px) and (max-width: 800px) {
   main > div {
     max-width: var(--viewwidth);
   }

--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,13 @@
 /* App colors */
 :root {
   --white: #f3f3f3;
-  --grey-extraextralight: #dcdcdc;
+  --grey-lightest: #dcdcdc;
   --grey-extralight: #cfcfcf;
-  --grey-light: #a3a3a3;
-  --grey: #494949;
-  --grey-dark: #2a2a2a;
-  --grey-extradark: #212121;
+  --grey-light: #bababa;
+  --grey: #a3a3a3;
+  --grey-dark: #494949;
+  --grey-extradark: #2a2a2a;
+  --grey-darkest: #212121;
   --black: #131313;
   --turquoise: #025a64;
   --turquoise-dark: #024047;
@@ -43,13 +44,14 @@
   --focus-color: var(--turquoise-dark);
   --button-text-color: var(--white);
   --navbar-background: var(--grey-extralight);
-  --navbar-menu: var(--grey-extraextralight);
+  --navbar-menu: var(--grey-lightest);
   --navbar-accent: var(--grey-extralight);
-  --navbar-focus: var(--grey-light);
-  --card-subheader: var(--grey);
-  --card-sidetext: var(--grey);
+  --navbar-focus: var(--grey);
+  --navbar-shadow: var(--grey-light);
+  --card-subheader: var(--grey-dark);
+  --card-sidetext: var(--grey-dark);
   --form-background-color: var(--grey-extralight);
-  --form-focus-color: var(--grey-extraextralight);
+  --form-focus-color: var(--grey-lightest);
 }
 
 /* Layout colors for dark color scheme */
@@ -59,12 +61,13 @@
   --primary-color: var(--peach);
   --focus-color: var(--peach-dark);
   --button-text-color: var(--black);
-  --navbar-background: var(--grey-extradark);
-  --navbar-menu: var(--grey-dark);
-  --navbar-accent: var(--grey);
-  --navbar-focus: var(--grey);
+  --navbar-background: var(--grey-darkest);
+  --navbar-menu: var(--grey-extradark);
+  --navbar-accent: var(--grey-dark);
+  --navbar-focus: var(--grey-dark);
+  --navbar-shadow: var(--grey-extradark);
   --card-subheader: var(--grey-extralight);
-  --card-sidetext: var(--grey-light);
+  --card-sidetext: var(--grey);
 }
 
 /* Layout */
@@ -72,12 +75,14 @@
   --spacing-xs: 0.25rem;
   --spacing-s: 0.5rem;
   --spacing-m: 1rem;
+  --spacing-ml: 1.5rem;
   --spacing-l: 2rem;
   --spacing-xl: 3rem;
   /* 100% device view height - navbar height, padding and margin */
   --viewheight: calc(100dvh - var(--spacing-xl) - 3 * var(--spacing-l));
   /* 100% device view width - padding */
   --viewwidth: calc(100dvw - 2 * var(--spacing-l));
+  --viewwidth-mobile: calc(100dvw - 2 * var(--spacing-ml));
   --max-content-width: 800px;
   --font: "Inter", "Roboto", sans-serif;
 }
@@ -113,7 +118,7 @@ a {
 main {
   min-height: var(--viewheight);
   padding: var(--spacing-l);
-  margin: var(--spacing-xl) 0 var(--spacing-l);
+  margin: var(--spacing-xl) 0 var(--spacing-ml);
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
@@ -125,7 +130,17 @@ main > div {
   width: calc(var(--max-content-width) - 2 * var(--spacing-l));
 }
 
-@media (max-width: 800px) {
+@media (max-width: 500px) {
+  main {
+    padding-top: var(--spacing-s);
+  }
+
+  main > div {
+    max-width: var(--viewwidth-mobile);
+  }
+}
+
+@media (min-width: 501px) and (max-width: 800px) {
   main > div {
     max-width: var(--viewwidth);
   }

--- a/src/views/landingView/LandingView.css
+++ b/src/views/landingView/LandingView.css
@@ -37,7 +37,7 @@
   font-weight: 600;
 }
 
-@media (min-height: 700px) {
+@media (min-height: 600px) {
   .infoContainer {
     margin-top: 10dvh;
   }


### PR DESCRIPTION
This PR adds the following features/fixes:

- Scroll to the top of the page when location is changed, e.g. when user navigates to another page
- Background scrolling is disabled and scrolling inside the mobile menu is enabled when mobile menu is open
- Change mobile menu width to cover the whole screen width
- Trap keyboard focus inside the mobile menu when it's open
- When mobile menu is open and user clicks outside it, the menu closes but nothing else happens, e.g. they can't accidentally click some button on the background