### PR TITLE
Fix dark mode synchronization

### DIFF
--- a/src/components/mobileMenu/MobileMenu.tsx
+++ b/src/components/mobileMenu/MobileMenu.tsx
@@ -8,7 +8,6 @@ import FormControlLabel from "@mui/material/FormControlLabel";
 import FormControl from "@mui/material/FormControl";
 import FormLabel from "@mui/material/FormLabel";
 import { ToggleButton } from "../toggleButton/ToggleButton";
-import { useColorScheme } from "../../hooks/useColorScheme";
 import { LanguageSelector } from "../languageSelector/LanguageSelector";
 import { NavigationLink } from "../../interfaces/common";
 import "./MobileMenu.css";
@@ -16,12 +15,15 @@ import "./MobileMenu.css";
 export const MobileMenu = ({
   navigationLinks,
   forwardedRef,
+  isDark,
+  handleDarkModeToggle,
 }: {
   navigationLinks: Array<NavigationLink>;
   forwardedRef: React.RefObject<HTMLDivElement>;
+  isDark: boolean;
+  handleDarkModeToggle: () => void;
 }) => {
   const { t } = useTranslation();
-  const { isDark, handleDarkModeToggle } = useColorScheme();
   const { currentLanguage, languages, changeLanguage } = LanguageSelector();
 
   return (

--- a/src/components/navbar/Navbar.css
+++ b/src/components/navbar/Navbar.css
@@ -91,14 +91,14 @@
   background-color: var(--background-color);
 }
 
-@media (max-width: 800px) {
+@media (max-width: 750px) {
   .navLinks,
   .darkModeButtonContainer {
     display: none;
   }
 }
 
-@media (min-width: 801px) {
+@media (min-width: 751px) {
   .menuButton {
     display: none;
   }

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -117,6 +117,8 @@ export const Navbar = () => {
           <MobileMenu
             navigationLinks={navigationLinks}
             forwardedRef={mobileMenuRef}
+            isDark={isDark}
+            handleDarkModeToggle={handleDarkModeToggle}
           />
         )}
       </div>

--- a/src/components/toggleButton/ToggleButton.css
+++ b/src/components/toggleButton/ToggleButton.css
@@ -7,8 +7,8 @@
 
 .toggleButtonContainer {
   position: relative;
-  height: 1.8rem;
-  width: 3.3rem;
+  height: 1.7rem;
+  width: 3.1rem;
 }
 
 .toggleButton {
@@ -23,8 +23,8 @@
 .toggleButton:before {
   content: "";
   position: absolute;
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 1.4rem;
+  height: 1.4rem;
   left: 0.2rem;
   top: 0.15rem;
   border-radius: 50%;


### PR DESCRIPTION
Dark mode toggle state was not synchronized between desktop and mobile, which cause the toggle to show wrong state when switching between screen sizes. This PR fixes that.

This PR also makes the dark mode switch a bit smaller.