### PR TITLE
Change dark mode button styling

### DIFF
--- a/src/components/contactForm/ContactForm.css
+++ b/src/components/contactForm/ContactForm.css
@@ -38,6 +38,7 @@
 .submitButton:disabled:hover,
 .submitButton:disabled:focus {
   background-color: var(--button-disabled-dark);
+  border: 1px solid var(--button-disabled-dark);
 }
 
 .alertMessage {

--- a/src/components/languageMenu/LanguageMenu.css
+++ b/src/components/languageMenu/LanguageMenu.css
@@ -21,11 +21,6 @@
   color: var(--primary-color);
 }
 
-.languageIcon:focus,
-.languageIcon:hover {
-  color: var(--focus-color) !important;
-}
-
 .languageMenu div {
   border-radius: 0;
   box-shadow: none;

--- a/src/components/toggleButton/ToggleButton.css
+++ b/src/components/toggleButton/ToggleButton.css
@@ -7,8 +7,8 @@
 
 .toggleButtonContainer {
   position: relative;
-  height: 1.7rem;
-  width: 3.1rem;
+  height: 1.85rem;
+  width: 3.3rem;
 }
 
 .toggleButton {
@@ -16,8 +16,8 @@
   width: 100%;
   height: 100%;
   border-radius: 25px;
-  border: 0;
-  background-color: var(--primary-color);
+  background-color: transparent;
+  border: 2px solid var(--toggle-button-outline-color);
 }
 
 .toggleButton:before {
@@ -25,8 +25,8 @@
   position: absolute;
   width: 1.4rem;
   height: 1.4rem;
-  left: 0.2rem;
-  top: 0.15rem;
+  left: 0.1rem;
+  top: 0.1rem;
   border-radius: 50%;
   background-color: var(--white);
   transition: all 0.3s ease;
@@ -38,15 +38,5 @@
 
 .toggleButton.right:before {
   transform: translateX(100%);
-  background-color: var(--black);
-}
-
-.toggleButton.left:hover,
-.toggleButton.left:focus {
-  background-color: var(--button-disabled-dark);
-}
-
-.toggleButton.right:hover,
-.toggleButton.right:focus {
-  background-color: var(--focus-color);
+  background-color: var(--primary-color);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -44,7 +44,10 @@
   --text-color: var(--black);
   --primary-color: var(--forest-green);
   --focus-color: var(--forest-green-dark);
+  --button-background-color: var(--forest-green);
   --button-text-color: var(--cream);
+  --button-focus-color: var(--forest-green-dark);
+  --button-focus-outline-color: var(--forest-green-dark);
   --navbar-background: var(--beige-light);
   --navbar-menu: var(--beige);
   --navbar-focus: var(--beige-dark);
@@ -53,6 +56,7 @@
   --card-sidetext: var(--brown);
   --form-background-color: var(--white);
   --form-focus-color: var(--paper);
+  --toggle-button-outline-color: var(--button-disabled);
 }
 
 /* Layout colors for dark color scheme */
@@ -61,7 +65,10 @@
   --text-color: var(--cream);
   --primary-color: var(--neon-green);
   --focus-color: var(--neon-green-light);
-  --button-text-color: var(--black);
+  --button-background-color: transparent;
+  --button-text-color: var(--cream);
+  --button-focus-color: var(--grey-dark);
+  --button-focus-outline-color: var(--primary-color);
   --navbar-background: var(--black);
   --navbar-menu: var(--grey-dark);
   --navbar-focus: var(--grey);
@@ -70,6 +77,7 @@
   --card-sidetext: var(--grey-light);
   --form-background-color: var(--cream);
   --form-focus-color: var(--beige-light);
+  --toggle-button-outline-color: var(--primary-color);
 }
 
 /* Layout */

--- a/src/views/landingView/LandingView.css
+++ b/src/views/landingView/LandingView.css
@@ -34,13 +34,15 @@
   justify-content: center;
   gap: var(--spacing-s);
   padding: 0.4rem;
-  background-color: var(--primary-color);
+  background-color: var(--button-background-color);
+  border: 1px solid var(--primary-color);
   color: var(--button-text-color) !important;
 }
 
 .pageLink:hover,
 .pageLink:focus {
-  background-color: var(--focus-color);
+  background-color: var(--button-focus-color);
+  border: 1px solid var(--button-focus-outline-color);
 }
 
 .highlight {


### PR DESCRIPTION
Change button styling on dark mode to be gentler to the eye by only using the primary color on outlines of the buttons and not on the background.

(Border was used in css istead of outline because outline looked bad when the button is not toggled)

Before:
![Screenshot 2023-11-03 at 15 21 33](https://github.com/veeraalt/portfolio/assets/36920208/8e24042b-f7a6-4fbb-bb60-af2f789b81a2)

After:
![Screenshot 2023-11-03 at 15 21 53](https://github.com/veeraalt/portfolio/assets/36920208/31955527-40ac-4300-bcb2-0a413155bc2f)
